### PR TITLE
Provide release mechanism in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ARDUINO_BOARD_FQDN = "esp32:esp32:esp32-DevKitLipo"
 ARDUINO_PROGRAMMER_PORT = /dev/ttyACM0
 ARDUINO_CLI_DOCKER_TAG = local/arduino-cli:latest
 BUILD_DIR = build
+RELEASE_VERSION_STRING=$(shell sed -n 's/^.*SoftwareVersion.* *= *//p' sketch_dreambox/sketch_dreambox.ino | sed 's/[;"]*//g')
 
 # ${BUILD_DIR}/${SOURCEDIR}.bin
 
@@ -23,6 +24,13 @@ ${BUILD_DIR}/%.bin: Makefile ${SOURCES}
 upload: binary
 	@echo "ready to upload file to board: ${ARDUINO_BOARD_FQDN}"
 	arduino-cli upload --input-dir ${BUILD_DIR} -p ${ARDUINO_PROGRAMMER_PORT} --fqbn ${ARDUINO_BOARD_FQDN}
+
+release: binary
+	@echo "==> Creating a release for version ${RELEASE_VERSION_STRING}"
+	@mkdir -p ${BUILD_DIR}/${RELEASE_VERSION_STRING}
+	@cp ${BUILD_DIR}/*.{bin,elf} ${BUILD_DIR}/${RELEASE_VERSION_STRING}/.
+	@zip -r ${BUILD_DIR}/${RELEASE_VERSION_STRING}.zip ${BUILD_DIR}/${RELEASE_VERSION_STRING}/ 1> /dev/null
+	@tar czf ${BUILD_DIR}/${RELEASE_VERSION_STRING}.tar.gz ${BUILD_DIR}/${RELEASE_VERSION_STRING}/
 
 docker: .built-docker
 


### PR DESCRIPTION
- version string is fetched from sketch INO file
- new "release" target is generating ZIP and TAR
  ball with proper version string
- solves #2 