### PR TITLE
Provide Makefile target for ctags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/*
 Arduino/
 build/
 .venv*/
+sketch_dreambox/.tags
+.ctags-files

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ clean:
 	rm -f .built*
 	rm -rf .venv
 	rm -rf Arduino/user
+	rm -f .ctags-*
+	rm -f ${SOURCEDIR}/.tags*
 
 clean-all: clean
 	rm -rf Arduino/
@@ -90,3 +92,14 @@ boards: .built-boards
 	done < $< ; \
 	else echo "---> MISSING requirements.boards.txt file"; \
 	fi
+
+ctags: .built-ctags
+
+.ctags-files: ${SOURCES}
+	ls -1 ${SOURCEDIR}/*.ino > $@
+
+${SOURCEDIR}/.tags: .ctags-files
+	arduino-ctags -R -L $< --langmap=C:.ino -f $@
+
+.built-ctags: ${SOURCEDIR}/.tags
+	@touch $@


### PR DESCRIPTION
- required for many IDE so that they will be able
  to get code completion in Arduino projects where
  multiple files are used but there is no include
  between them