### PR TITLE
Provide an interface writing AP settings

### DIFF
--- a/sketch_dreambox/A60PersistentSettings.ino
+++ b/sketch_dreambox/A60PersistentSettings.ino
@@ -72,3 +72,24 @@ void settingsWrite(DmrSettingsS *dmrSettings)
 
   settingsPrintMsg("settingsWrite, finished");
 }
+
+void settingsAddWifiAp(DmrSettingsS* dmrSettings, WifiSettingS* wifiAp, int slot)
+{
+  // write AP settings into a distinct slot
+  settingsPrintMsg("settingsWriteWifi, start");
+
+  if (slot >= SETTINGS_MAX_WIFI_AP) {
+    settingsPrintMsg("settingsWriteWifi, failed => invalid slot");
+    return;
+  }
+
+  // erase that wifi slot
+  memset(dmrSettings->wifisettings[slot].ssid, 0, SETTINGS_WIFI_SSID_LEN);
+  memset(dmrSettings->wifisettings[slot].passwd, 0, SETTINGS_WIFI_PASSWD_LEN);
+
+  // copy new items
+  memcpy(dmrSettings->wifisettings[slot].ssid, wifiAp->ssid, SETTINGS_WIFI_SSID_LEN);
+  memcpy(dmrSettings->wifisettings[slot].passwd, wifiAp->passwd, SETTINGS_WIFI_PASSWD_LEN);
+
+  settingsPrintMsg("settingsWriteWifi, finished");
+}

--- a/sketch_dreambox/Settings.h
+++ b/sketch_dreambox/Settings.h
@@ -2,9 +2,12 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#define SETTINGS_WIFI_SSID_LEN 32
+#define SETTINGS_WIFI_PASSWD_LEN 16
+
 typedef struct _WifiSettingS {
-  char ssid[33];
-  char passwd[17];
+  char ssid[SETTINGS_WIFI_SSID_LEN + 1];
+  char passwd[SETTINGS_WIFI_PASSWD_LEN + 1];
 } WifiSettingS;
 
 typedef struct _TalkGroupS {
@@ -23,6 +26,8 @@ typedef struct _RepeaterS {
   TalkGroupS  groups[10];
 } RepeaterS;
 
+#define SETTINGS_MAX_WIFI_AP 4
+
 
 typedef struct _RepeaterConfigS {
   RepeaterS   repeater[50];
@@ -31,7 +36,7 @@ typedef struct _RepeaterConfigS {
 
 typedef struct _DmrSettingsS {
   int           version;
-  WifiSettingS  wifisettings[4];
+  WifiSettingS  wifisettings[SETTINGS_MAX_WIFI_AP];
   uint8_t       audioLevel;       //  1-9; default = 8
   uint8_t       micLevel;         //  0-15, mic gain setting
   char          callSign[12];     // callsign, max 12 chars
@@ -62,5 +67,8 @@ void settingsWrite(DmrSettingsS* dmrSettings);
 
 // read settings from EEPROM into dmrSettings
 void settingsRead(DmrSettingsS* dmrSettings);
+
+// write wifi settings into to a distinct slot
+void settingsAddWifiAp(DmrSettingsS* dmrSettings, WifiSettingS* wifiAp, int slot);
 
 #endif /* SETTINGS_H */


### PR DESCRIPTION
- closes #31
- copy Wifi AP settings into dmrSettings
- detects when slot number is out of range
- erases old settings before copying new one
- tested on Olimex board