### PR TITLE
fix missing TFT file in release ZIP file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ check-changes:
 ${BUILD_DIR}/%.zip: check-changes esp-binary manifest ${RELEASE_DIR}
 	@echo "==> Creating a release $@"
 	@cp ${BUILD_DIR}/*.{bin,elf} ${RELEASE_DIR}/.
+	@cp hmi/*.tft ${RELEASE_DIR}/.
 	@( \
 		cd ${BUILD_DIR} ; \
 		zip -r ${RELEASE_NAME}.zip ${RELEASE_NAME}/ 1> /dev/null ; \


### PR DESCRIPTION
- closes #49
- add the TFT files located in HMI folder when
  building a release