### PR TITLE
Disable SUDO mode when asking for GIT hash

### DIFF
--- a/eim-service/deployment/roles/eim/tasks/main.yml
+++ b/eim-service/deployment/roles/eim/tasks/main.yml
@@ -19,6 +19,7 @@
   when: inventory_hostname in groups.production
 
 - name: Get current GIT commit
+  become: false
   delegate_to: localhost
   shell:
     cmd: git rev-parse HEAD


### PR DESCRIPTION
- when deploying to production SUDO is enabled by default
- this would block getting the GIT hash from the local repository