### PR TITLE
eim - provide new endpoint for repeater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ sketch_dreambox/.tags
 **/.idea/**/*
 .pushed-*
 **/venv
+__pycache__/

--- a/eim-service/deployment/group_vars/local.yml
+++ b/eim-service/deployment/group_vars/local.yml
@@ -1,7 +1,7 @@
 ansible_become: false
 ansible_connection: local
 service_user: "{{ lookup('env', 'USER') }}"
-uri_expected: http://127.0.0.1/system/info
+uri_expected: http://localhost:80/system/info
 eim_docker_core: "eim-core:latest"
 eim_docker_db : "eim-mongodb:latest"
 eim_docker_harvester: "eim-harvester:latest"

--- a/eim-service/docker/eim-core/src/common/tools.py
+++ b/eim-service/docker/eim-core/src/common/tools.py
@@ -1,0 +1,9 @@
+
+def compute_end_index(len: int, skip: int = 0, limit: int = 0) -> (int, int):
+
+    end = len
+    if len > (skip + limit):
+        end = skip + limit
+    if limit == 0:
+        end = len
+    return skip, end

--- a/eim-service/docker/eim-core/src/tests/test_common.py
+++ b/eim-service/docker/eim-core/src/tests/test_common.py
@@ -1,0 +1,39 @@
+
+import pytest
+from common.tools import compute_end_index
+
+
+@pytest.mark.parametrize(
+    argnames="length, skip, limit, expected",
+    argvalues=[
+        (0, 0, 0, (0, 0)),
+        (5, 0, 10, (0, 5)),
+        (15, 0, 10, (0, 10)),
+        (15, 0, 15, (0, 15)),
+        (15, 5, 5, (5, 10)),
+        (15, 10, 5, (10, 15)),
+        (15, 15, 5, (15, 15)),
+        (15, 0, 0, (0, 15))
+
+    ],
+    ids=[
+        "all_zero",
+        "len<limit",
+        "len>limit",
+        "len=limit",
+        "skip=limit",
+        "skip>limit",
+        "no_items_left",
+        "0=skip=limit"
+    ]
+)
+def test_compute_end_index(length, skip, limit, expected):
+
+    test_list = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    ]
+
+    start, end = compute_end_index(length, skip, limit)
+    # print(f"{len}:{skip}:{limit} ==> {test_list[start:end]}")
+
+    assert (start, end) == expected

--- a/eim-service/docker/eim-harvester/src/db/mongo.py
+++ b/eim-service/docker/eim-harvester/src/db/mongo.py
@@ -64,6 +64,21 @@ class MongoDB:
 
         logger.debug(f"list_indexes: {col.list_indexes()}")
 
+        if "id_callsign_updated" not in col.list_indexes():
+            idx_callsign = ("callsign", DESCENDING)
+            idx_status = ("status", DESCENDING)
+            idx_repeater_id = ("repeaterid", DESCENDING)
+            idx_updated = ("last_updated_ts", DESCENDING)
+
+            col.create_index(
+                [idx_repeater_id, idx_callsign, idx_status, idx_updated],
+                unique=False,
+                background=True,
+                name="id_callsign_updated"
+            )
+
+            logger.debug("created index \"id_callsign_updated\"")
+
         if "id_status_updated" not in col.list_indexes():
             idx_repeater_id = ("repeaterid", DESCENDING)
             idx_status = ("status", DESCENDING)

--- a/sketch_dreambox/sketch_dreambox.ino
+++ b/sketch_dreambox/sketch_dreambox.ino
@@ -1,5 +1,5 @@
 //  --
-char SoftwareVersion[21] = "SM7ECA-210222-2O";
+char SoftwareVersion[21] = "SM7ECA-210222-2P";
 #include <Arduino.h>
 #include <WiFiMulti.h>
 #include <HTTPClient.h>
@@ -32,7 +32,7 @@ char SoftwareVersion[21] = "SM7ECA-210222-2O";
 #define FUNC_DISABLE                   0x02
 
 // ---------------------------------------------------- Pin definitions
-#define  beepPin    14  //beepPin; OUTPUT, this is is actually A0 but we are to use it 
+#define  beepPin    14  //beepPin; OUTPUT, this is is actually A0 but we are to use it
 //for the beeper as pin 13 was used by SPI in this case
 
 //-------------------------------------------------------------- Main state machine states


### PR DESCRIPTION
- closes #62
- new endpoint, repeater/callsign/{callsign}
- not done yet, index is missing
- limit and skip are working
- added pytests for computing start, end when 
  trying to limit the number of returned objects
  with skip and limit