### PR TITLE
Redirect traffic that hits ROOT to /docs

### DIFF
--- a/eim-service/docker/eim-core/src/main.py
+++ b/eim-service/docker/eim-core/src/main.py
@@ -1,5 +1,6 @@
 import os
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 
 from routers import repeater
 from routers import hotspot
@@ -21,6 +22,14 @@ app = FastAPI(
                 f'Commit at Github: <a target="_blank" href="{github_ref}/commit/{eim_git_hash}">{eim_git_hash[:6]}</a>',
     version=f"0.1.{eim_git_hash[:6]}"
 )
+
+
+@app.get("/", include_in_schema=False)
+def redirect_docs():
+    """Redirect ROOT to docs, so that a user by default end up reading something."""
+    response = RedirectResponse(url="/docs")
+    return response
+
 
 app.include_router(repeater.router)
 app.include_router(hotspot.router)

--- a/tests/test_eim_service.py
+++ b/tests/test_eim_service.py
@@ -91,3 +91,16 @@ def test_hotspot(callsign: str, expected_status: int):
 	"""
 	response = requests.get(url=f"http://localhost/hotspot/callsign/{callsign}")
 	assert response.status_code == expected_status
+
+
+def test_redirect_root():
+	"""Given a GET request sent towards root, we expect to be redirected to /docs"""
+
+	# call the UUT
+	response = requests.get(url=f"http://localhost", allow_redirects=True)
+	
+	# assert results
+	assert response.status_code == 200
+	assert response.url == "http://localhost/docs"
+	assert response.history[0].is_redirect
+	assert response.history[0].status_code == 307


### PR DESCRIPTION
- this will ensure that people entering just the
  service URL will end up in the documentation and
  receiving an error message from the web browser
- added function tests in order to discover the
  URL redirect
- closes #80 