### PR TITLE
Remove master_id and repeater_id from TG

### DIFF
--- a/eim-service/docker/eim-core/src/common/brandmeister.py
+++ b/eim-service/docker/eim-core/src/common/brandmeister.py
@@ -38,8 +38,6 @@ class Brandmeister:
         for tg in profile.get("staticSubscriptions"):
             tg_object = {
                 "tg_id": tg["talkgroup"],
-                "master_id": tg["networkid"],
-                "rep_id": tg["repeaterid"],
                 "ts": tg["slot"],
                 "is_dynamic": False
             }
@@ -49,8 +47,6 @@ class Brandmeister:
         for tg in profile.get("dynamicSubscriptions"):
             tg_object = {
                 "tg_id": tg["talkgroup"],
-                "master_id": tg["networkid"],
-                "rep_id": tg["repeaterid"],
                 "ts": tg["slot"],
                 "is_dynamic": True
             }

--- a/eim-service/docker/eim-core/src/common/definitions.py
+++ b/eim-service/docker/eim-core/src/common/definitions.py
@@ -10,12 +10,11 @@ field_cc = Field(..., example=4, description="color code")
 field_callsign = Field(..., example="PI1SPA", description="repeater callsign/owners callsign when hotspot")
 field_location = Field(..., example="59.426891,24.819180", description="lat, long if provided")
 field_city = Field(..., example="Varberg, SE", description="city, country string provided by owner")
+field_max_ts = Field(..., example="2", description="number of time slots used by the repeater/hotspot")
 
 
 class TalkGroup(BaseModel):
     tg_id: int = Field(..., example=2401, description="talk group ID")
-    master_id: int = Field(..., example=2401, description="current DMR ID of master handling the traffic")
-    rep_id: int = Field(..., example=204342, description="DMR ID of repeater/hotspot handling this TG")
     ts: int = field_ts
     is_dynamic: bool = Field(..., example=True, description="whether this TG is dynamic")
 
@@ -28,8 +27,7 @@ class Repeater(BaseModel):
     tx: int = field_tx
     rx: int = field_rx
     cc: int = field_cc
-    ts: int = field_ts
-    max_ts: int
+    max_ts: int = field_max_ts
     name: str = field_callsign
     location: str = field_location
     city: str = field_city

--- a/eim-service/docker/eim-core/src/db/mongodb.py
+++ b/eim-service/docker/eim-core/src/db/mongodb.py
@@ -67,7 +67,6 @@ class MongoDB:
             "tx": float(db_entry["tx"]) * 1e6,
             "rx": float(db_entry["rx"]) * 1e6,
             "cc": int(db_entry["colorcode"]),
-            "ts": 1,
             "max_ts": 0,
             "name": db_entry["callsign"],
             "location": f"{db_entry['lat']},{db_entry['lng']}",

--- a/eim-service/docker/eim-core/src/routers/repeater.py
+++ b/eim-service/docker/eim-core/src/routers/repeater.py
@@ -93,7 +93,10 @@ async def repeater_dmrid(
 
         tgs = bm.get_talk_groups(dmr_id=dmr_id)
         logger.debug(f"received {len(tgs)} talk groups for DMR: {dmr_id}")
+
         list_repeater[0].tg = tgs
+        list_repeater[0].max_ts = len(set([tg.ts for tg in tgs]))
+
         return_data = list_repeater[0]
     else:
         response.status_code = status.HTTP_204_NO_CONTENT

--- a/tests/test_eim_service.py
+++ b/tests/test_eim_service.py
@@ -54,11 +54,13 @@ def test_repeater_callsign(call_sign: str, expected_status: int, expected_len: i
 	argnames="dmr_id,expected_status,expected_len",
 	argvalues=[
 		(204342, 200, 1),
-		(999999, 204, 0)
+		(999999, 204, 0),
+		(240701, 200, 1)
 	],
 	ids=[
 		"valid_dmr_id",
-		"invalid_dmr_id"
+		"invalid_dmr_id",
+		"check_tgs"
 	]
 )
 def test_repeater_dmrid(dmr_id: int, expected_status: int, expected_len: int):
@@ -67,6 +69,21 @@ def test_repeater_dmrid(dmr_id: int, expected_status: int, expected_len: int):
 	if response.status_code == 200:
 		assert not isinstance(response.json(), list)
 		assert isinstance(response.json(), dict)
+		
+		# check talk groups
+		repeater = response.json()
+		assert isinstance(repeater['tg'], list)
+
+		# check max_ts
+		assert repeater['max_ts'] == len(set([tg['ts'] for tg in repeater['tg']]))
+		
+		# ensure that we have removed "ts" from Repeater response model
+		assert "ts" not in repeater.keys()
+
+		# check whether we have removed repeater ID and master ID from TG
+		for tg in repeater["tg"]:
+			assert "master_id" not in tg.keys(), "unexpected key \"master_id\""
+			assert "rep_id" not in tg.keys(), "unexpected key \"rep_id\""
 
 
 def test_repeater_location():


### PR DESCRIPTION
- this is redundant information
- remove ts from Repeater response model
- propagate ts_max based on total number of unique TS in TGs
- helps to reduce amount of data parsed by ESP32
- provide function tests
- add field description
- closes #86 
- closes #84 