### PR TITLE
Provide location-based query for repeater

### DIFF
--- a/eim-service/docker/eim-harvester/src/db/mongo.py
+++ b/eim-service/docker/eim-harvester/src/db/mongo.py
@@ -1,6 +1,6 @@
 import os
 
-from pymongo import MongoClient, DESCENDING, InsertOne, UpdateOne, ReplaceOne, DeleteOne
+from pymongo import MongoClient, DESCENDING, InsertOne, UpdateOne, ReplaceOne, DeleteOne, GEOSPHERE
 from pymongo.errors import ConnectionFailure, BulkWriteError
 from pymongo.database import Database
 from pymongo.results import BulkWriteResult
@@ -14,6 +14,7 @@ from typing import List, Optional
 
 
 logger = harvester_logger("mongodb")
+
 
 class MongoDbError(BaseException):
 
@@ -63,6 +64,11 @@ class MongoDB:
     def _create_indexes(col: Collection):
 
         logger.debug(f"list_indexes: {col.list_indexes()}")
+
+        if "id_2dsphere" not in col.list_indexes():
+            idx_location = ("loc", GEOSPHERE)
+            col.create_index([idx_location])
+            logger.debug("created index for GEOSPHERE")
 
         if "id_callsign_updated" not in col.list_indexes():
             idx_callsign = ("callsign", DESCENDING)

--- a/eim-service/docker/eim-harvester/src/dmr/definitions.py
+++ b/eim-service/docker/eim-harvester/src/dmr/definitions.py
@@ -2,6 +2,9 @@ from typing import Dict
 from common.time import timestr_to_timestamp
 
 
+DEFAULT_LOC = {"type": "Point", "coordinates": [0.000000, 0.000000]}
+
+
 class Repeater:
     """Repeater Data object"""
 
@@ -16,6 +19,8 @@ class Repeater:
     lastKnownMaster: str
     lat: str
     lng: str
+    loc: Dict
+    loc_valid : bool
     city: str
     website: str
     pep: str
@@ -30,6 +35,35 @@ class Repeater:
         self.__dict__.update(_dict)
         if "last_updated" in _dict.keys() and self.last_updated:
             self.last_updated_ts = timestr_to_timestamp(self.last_updated)
+
+        self.__update_location(self.lng, self.lat)
+
+    def __update_location(self, lng: str, lat: str):
+        """
+        Update the location so that we could do location searches based
+        on long lat.
+
+            - if invalid numbers are detected, set 0.00000, 0.00000
+            - range check for +/-180, +/-90
+            - both have to differ from 0.000000
+        """
+        self.loc = DEFAULT_LOC
+        self.loc_valid = False
+
+        try:
+            longitude = float(lng)
+            latitude = float(lat)
+        except BaseException as ex:
+            return
+
+        if longitude == 0.0 and latitude == 0.0:
+            return
+
+        if not (-180 <= longitude <= 180) or not (-90 <= latitude <= 90):
+            return
+
+        self.loc = {"type": "Point", "coordinates": [longitude, latitude]}
+        self.loc_valid = True
 
     def dict(self):
         return self.__dict__

--- a/sketch_dreambox/sketch_dreambox.ino
+++ b/sketch_dreambox/sketch_dreambox.ino
@@ -1,5 +1,5 @@
 //  --
-char SoftwareVersion[21] = "SM7ECA-210307-3B";
+char SoftwareVersion[21] = "SM7ECA-210310-3C";
 #include <Arduino.h>
 #include <WiFiMulti.h>
 #include <HTTPClient.h>

--- a/tests/test_eim_service.py
+++ b/tests/test_eim_service.py
@@ -3,13 +3,15 @@ import pytest
 import requests
 from typing import Dict
 
+BASE_URL = "http://localhost"
+
 
 def test_sysinfo():
-	response = requests.get(url="http://localhost/system/info")
+	response = requests.get(url=f"{BASE_URL}/system/info")
 	assert response.status_code == 200
 
 def test_docs():
-	response = requests.get(url="http://localhost/docs")
+	response = requests.get(url=f"{BASE_URL}/docs")
 	assert response.status_code == 200
 
 
@@ -25,7 +27,7 @@ def test_docs():
 	]
 )
 def test_repeater_master(master_id: int, expected_status: int, expected_len: int):
-	response = requests.get(url=f"http://localhost/repeater/master/{master_id}?limit=5&skip=0")
+	response = requests.get(url=f"{BASE_URL}/repeater/master/{master_id}?limit=5&skip=0")
 	assert response.status_code == expected_status
 	if response.status_code == 200:
 		assert len(response.json()) == expected_len
@@ -43,14 +45,14 @@ def test_repeater_master(master_id: int, expected_status: int, expected_len: int
 	]
 )
 def test_repeater_callsign(call_sign: str, expected_status: int, expected_len: int):
-	response = requests.get(url=f"http://localhost/repeater/callsign/{call_sign}")
+	response = requests.get(url=f"{BASE_URL}/repeater/callsign/{call_sign}")
 	assert response.status_code == expected_status
 	if response.status_code == 200:
 		assert len(response.json()) == expected_len
 
 
 def test_no_repeater_dmr_id():
-	response = requests.get(url=f"http://localhost/repeater/dmr/240701")
+	response = requests.get(url=f"{BASE_URL}/repeater/dmr/240701")
 	assert response.status_code == 404
 
 
@@ -70,7 +72,7 @@ def test_no_repeater_dmr_id():
 	]
 )
 def test_repeater_dmrid(dmr_id: int, expected_status: int, expected_len: int):
-	response = requests.get(url=f"http://localhost/dmr/{dmr_id}")
+	response = requests.get(url=f"{BASE_URL}/dmr/{dmr_id}")
 	assert response.status_code == expected_status
 	if response.status_code == 200:
 		assert not isinstance(response.json(), list)
@@ -93,7 +95,7 @@ def test_repeater_dmrid(dmr_id: int, expected_status: int, expected_len: int):
 
 
 def test_repeater_location():
-	response = requests.get(url=f"http://localhost/repeater/location?city=Gothenburg&country=SE&distance=40")
+	response = requests.get(url=f"{BASE_URL}/repeater/location?city=Gothenburg&country=SE&distance=40")
 	assert response.status_code == 501
 
 
@@ -112,7 +114,7 @@ def test_hotspot(callsign: str, expected_status: int):
 	"""
 	Given a valid callsign, we expected that will receive a number of hotspots
 	"""
-	response = requests.get(url=f"http://localhost/hotspot/callsign/{callsign}")
+	response = requests.get(url=f"{BASE_URL}/hotspot/callsign/{callsign}")
 	assert response.status_code == expected_status
 
 
@@ -120,10 +122,23 @@ def test_redirect_root():
 	"""Given a GET request sent towards root, we expect to be redirected to /docs"""
 
 	# call the UUT
-	response = requests.get(url=f"http://localhost", allow_redirects=True)
+	response = requests.get(url=BASE_URL, allow_redirects=True)
 	
 	# assert results
 	assert response.status_code == 200
-	assert response.url == "http://localhost/docs"
+	assert response.url == f"{BASE_URL}/docs"
 	assert response.history[0].is_redirect
 	assert response.history[0].status_code == 307
+
+def test_repeater_location():
+
+	longitude = 12.4605814
+	latitude = 56.8984846
+	distance = 30	
+
+	req_url = f"{BASE_URL}/repeater/location?longitude={longitude}&latitude={latitude}&distance={distance}"
+
+	response = requests.get(url=req_url)
+
+	# assert results
+	assert response.status_code == 200


### PR DESCRIPTION
- returns a list of repeater matching max distance
  from a given geographical position
- add function test case for this query
- reduce technical debt in function test
- MongoDB, create "2dsphere" index in "loc"
- Harvester, ensure that all entries are scanned
  and a new "loc" object is created when geographical
  position is valid
- make use of Falkenberg position and distance of 30km
  as default value
- closes #71 