### PR TITLE
EIM - query for repeater with callsign supports "contains"

### DIFF
--- a/eim-service/docker/eim-core/src/db/mongodb.py
+++ b/eim-service/docker/eim-core/src/db/mongodb.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import re
 from urllib.parse import quote_plus
 
 from pymongo import MongoClient
@@ -122,12 +123,10 @@ class MongoDB:
     def get_repeater_by_callsign(self, call_sign) -> Optional[List[RepeaterItem]]:
 
         col = self._db.get_collection("repeater")
-        timestamp_24_hours_ago = int(datetime.now().timestamp()) - 86400
 
         query = {
             "status": "3",
-            "callsign": call_sign,
-            "last_updated_ts": {"$gt": timestamp_24_hours_ago}
+            "callsign": {"$regex": re.escape(call_sign)}
         }
 
         docs = col.find(filter=query, limit=0).sort("callsign")

--- a/eim-service/docker/eim-harvester/src/db/mongo.py
+++ b/eim-service/docker/eim-harvester/src/db/mongo.py
@@ -1,6 +1,6 @@
 import os
 
-from pymongo import MongoClient, DESCENDING, InsertOne, UpdateOne, ReplaceOne, DeleteOne, GEOSPHERE
+from pymongo import MongoClient, DESCENDING, InsertOne, UpdateOne, ReplaceOne, DeleteOne, GEOSPHERE, TEXT
 from pymongo.errors import ConnectionFailure, BulkWriteError
 from pymongo.database import Database
 from pymongo.results import BulkWriteResult
@@ -67,7 +67,10 @@ class MongoDB:
 
         if "id_2dsphere" not in col.list_indexes():
             idx_location = ("loc", GEOSPHERE)
-            col.create_index([idx_location])
+            col.create_index(
+                [idx_location],
+                name="id_2dsphere"
+            )
             logger.debug("created index for GEOSPHERE")
 
         if "id_callsign_updated" not in col.list_indexes():

--- a/sketch_dreambox/sketch_dreambox.ino
+++ b/sketch_dreambox/sketch_dreambox.ino
@@ -1,5 +1,5 @@
 //  --
-char SoftwareVersion[21] = "SM7ECA-210310-3C";
+char SoftwareVersion[21] = "SM7ECA-210310-3D";
 #include <Arduino.h>
 #include <WiFiMulti.h>
 #include <HTTPClient.h>

--- a/tests/test_eim_service.py
+++ b/tests/test_eim_service.py
@@ -37,11 +37,13 @@ def test_repeater_master(master_id: int, expected_status: int, expected_len: int
 	argnames="call_sign,expected_status,expected_len",
 	argvalues=[
 		("PI1SPA", 200, 1),
-		("DL7MCK", 204, 0)
+		("DL7MCK", 204, 0),
+		("AVQ", 200, 2)
 	],
 	ids=[
-		"valid_callsign",
-		"invalid_callsign"
+		"callsign_valid",
+		"callsign_invalid",
+		"callsign_regex"
 	]
 )
 def test_repeater_callsign(call_sign: str, expected_status: int, expected_len: int):


### PR DESCRIPTION
- when searching for a repeater/callsign the interface should
  support "contains"
- this is required because sometimes there are additional
  characters in the call sign field
- minimum length is 3 character
- closes #91 