### PR TITLE
ESP - provide Make target for erasing EEPROM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ esp-upload: esp-binary
 	@echo "ready to upload file to board: ${ARDUINO_BOARD_FQDN}"
 	arduino-cli upload --input-dir ${BUILD_DIR} -p ${ARDUINO_PROGRAMMER_PORT} --fqbn ${ARDUINO_BOARD_FQDN}
 
+esp-erase-eeprom: venv
+	@read -p "Please, unplug power from display..." ANSWER
+	@( \
+		. .venv/bin/activate; \
+		esptool.py erase_flash; \
+	)
+	@echo "==> Done, EEPROM has been erased"
+
 release: ${BUILD_DIR}/${RELEASE_NAME}.zip unit-test function-test eim-release release-tag
 	@echo "==> Release DONE, push tags and upload binaries to Github https://github.com/sm7eca/dmr-dreambox/releases"
 

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,1 +1,2 @@
 pyserial
+esptool

--- a/sketch_dreambox/sketch_dreambox.ino
+++ b/sketch_dreambox/sketch_dreambox.ino
@@ -5,7 +5,7 @@ char SoftwareVersion[21] = "SM7ECA-210317-3N";
 #include <HTTPClient.h>
 #include <ArduinoJson.h>
 #include "Settings.h"
-#define INC_DMR_CALLS
+// #define INC_DMR_CALLS
 
 //----------------------------------------- DMR MODULE COMMANDS
 //


### PR DESCRIPTION
- required when we do major changes in EEPROM format
- "make esp-erase-eeprom"
- doesn't change ESP code, nor EIM code, it just provides a tool in Linux make environment