### PR TITLE
EIM - add number of users in DB to system info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ venv-test: .built-venv-test
 		echo "==> run function tests"; \
 		python3 -m venv .venv ; \
 		. .venv/bin/activate ; \
-		python3 -m pytest -xvs tests/ ; \
+		python3 -m pytest -xvs --host localhost tests/ ; \
 	)
 	@touch $@
 

--- a/eim-service/docker/eim-core/src/common/definitions.py
+++ b/eim-service/docker/eim-core/src/common/definitions.py
@@ -15,6 +15,7 @@ field_city = Field(..., example="Varberg, SE", description="city, country string
 field_max_ts = Field(..., example="2", description="number of time slots used by the repeater/hotspot")
 field_maintainer = Field(..., example="Max Mustermann", description="Maintainer of this service")
 field_git_commit = Field(..., example="5cebad", description="short GIT hash")
+field_num_user = Field(..., example=202000, description="number of DMR users stored in DB")
 field_num_repeater = Field(..., example=66440, description="number of receiver items stored in DB")
 field_release_name = Field(..., example="dmr_dreambox_SM7ECA-210302-2S", description="EIM release name")
 field_uptime = Field(..., example="800s", description="uptime in seconds")
@@ -70,6 +71,7 @@ class SysInfo(BaseModel):
     release: str = field_release_name
     git_commit: str = field_git_commit
     maintainer: str = field_maintainer
+    user: int = field_num_user
     repeater: int = field_num_repeater
 
 

--- a/eim-service/docker/eim-core/src/db/mongodb.py
+++ b/eim-service/docker/eim-core/src/db/mongodb.py
@@ -205,10 +205,10 @@ class MongoDB:
         - throw an exception if collection doesn't exist
 
         """
-        col: Collection = self._db.get_collection("repeater")
-        if "repeater" not in self._db.list_collection_names():
-            raise MongoDbError(f"no collection {col} found in DB")
+        if collection not in self._db.list_collection_names():
+            return 0
 
+        col: Collection = self._db.get_collection(collection)
         num_docs = col.count_documents(filter={})
         return num_docs
 

--- a/eim-service/docker/eim-core/src/routers/info.py
+++ b/eim-service/docker/eim-core/src/routers/info.py
@@ -29,13 +29,22 @@ async def get_sys_info():
         uptime = int(datetime.now().timestamp() - fname.stat().st_ctime)
 
     db = MongoDB()
-    num_repeater: int = db.count_docs(collection="repeater")
+    try:
+        num_repeater: int = db.count_docs(collection="repeater")
+    except Exception as error:
+        num_repeater = 0
+
+    try:
+        num_users: int = db.count_docs(collection="dmr_user")
+    except Exception as error:
+        num_users = 0
 
     info = {
         "uptime": uptime_2_human_string(uptime),
         "git_commit": git_hash,
         "release": dmr_release_name,
         "maintainer": "Arne Nilsson (SM7ECA), Sebastian Mangelsen (SM6-8506)",
+        "user": num_users,
         "repeater": num_repeater}
 
     return SysInfo(**info)

--- a/sketch_dreambox/sketch_dreambox.ino
+++ b/sketch_dreambox/sketch_dreambox.ino
@@ -1,5 +1,5 @@
 //  --
-char SoftwareVersion[21] = "SM7ECA-210319-3O";
+char SoftwareVersion[21] = "SM7ECA-210319-3P";
 #include <Arduino.h>
 #include <WiFiMulti.h>
 #include <HTTPClient.h>
@@ -283,7 +283,7 @@ WifiSettingS  WifiAp;
 
 void  NXinitDisplay();
 void  NXinitialSetup();
-void  NX_P0_showState();  
+void  NX_P0_showState();
 void  NX_P0_DisplayMainPage();
 void  NX_P0_DisplayReceive(boolean rec_on, byte calltype, uint32_t TGId);
 void  NX_P0_DisplayTransmit(boolean on);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+
+import pytest
+
+def pytest_addoption(parser):
+	""" provide a new command line parameter """
+	parser.addoption(
+		"--host",
+		default="localhost",
+		help="host: IP addr or hostname for DUT"
+	)
+
+
+@pytest.fixture
+def hostname(request):
+	return request.config.getoption("--host")

--- a/tests/test_eim_service.py
+++ b/tests/test_eim_service.py
@@ -4,15 +4,21 @@ import requests
 from time import sleep
 from typing import Dict
 
-BASE_URL = "http://localhost/api/v1"
+API_ROOT = "api/v1"
 
 
-def test_sysinfo():
-	response = requests.get(url=f"{BASE_URL}/system/info")
+def test_sysinfo(hostname):
+	url = f"http://{hostname}/{API_ROOT}/system/info"
+	response = requests.get(url=url)
 	assert response.status_code == 200
+	assert response.json()
+	data = response.json()
+	assert "user" in data.keys()
+	assert "repeater" in data.keys()
 
-def test_docs():
-	response = requests.get(url=f"{BASE_URL}/docs")
+def test_docs(hostname):
+	url = f"http://{hostname}/{API_ROOT}/docs"
+	response = requests.get(url=url)
 	assert response.status_code == 200
 
 
@@ -27,8 +33,9 @@ def test_docs():
 		"invalid master_id"
 	]
 )
-def test_repeater_master(master_id: int, expected_status: int, expected_len: int):
-	response = requests.get(url=f"{BASE_URL}/repeater/master/{master_id}?limit=5&skip=0")
+def test_repeater_master(master_id: int, expected_status: int, expected_len: int, hostname):
+	url = f"http://{hostname}/{API_ROOT}/repeater/master/{master_id}?limit=5&skip=0"
+	response = requests.get(url=url)
 	assert response.status_code == expected_status
 	if response.status_code == 200:
 		assert len(response.json()) == expected_len
@@ -47,18 +54,21 @@ def test_repeater_master(master_id: int, expected_status: int, expected_len: int
 		"callsign_regex"
 	]
 )
-def test_repeater_callsign(call_sign: str, expected_status: int, expected_len: int):
-	response = requests.get(url=f"{BASE_URL}/repeater/callsign/{call_sign}")
+def test_repeater_callsign(call_sign: str, expected_status: int, expected_len: int, hostname):
+	url = f"http://{hostname}/{API_ROOT}/repeater/callsign/{call_sign}"
+	response = requests.get(url=url)
 	assert response.status_code == expected_status
 	if response.status_code == 200:
 		assert len(response.json()) == expected_len
 
-def test_invalid_api_endpoint_exception_covered():
-	response = requests.get(url=f"{BASE_URL}/repeater/dmr/A87987d9a8s7d9?lim=12")
+def test_invalid_api_endpoint_exception_covered(hostname):
+	url = f"http://{hostname}/{API_ROOT}/repeater/dmr/A87987d9a8s7d9?lim=12"
+	response = requests.get(url)
 	assert response.status_code == 404
 
-def test_no_repeater_dmr_id():
-	response = requests.get(url=f"{BASE_URL}/repeater/dmr/2407099")
+def test_no_repeater_dmr_id(hostname):
+	url = f"http://{hostname}/{API_ROOT}/repeater/dmr/2407099"
+	response = requests.get(url)
 	assert response.status_code == 404
 
 @pytest.mark.parametrize(
@@ -76,8 +86,9 @@ def test_no_repeater_dmr_id():
 		"check_hotspot"
 	]
 )
-def test_repeater_dmrid(dmr_id: int, expected_status: int, expected_len: int):
-	response = requests.get(url=f"{BASE_URL}/dmr/{dmr_id}")
+def test_repeater_dmrid(dmr_id: int, expected_status: int, expected_len: int, hostname):
+	url = f"http://{hostname}/{API_ROOT}/dmr/{dmr_id}"
+	response = requests.get(url)
 	assert response.status_code == expected_status
 	if response.status_code == 200:
 		assert not isinstance(response.json(), list)
@@ -106,7 +117,8 @@ def test_repeater_dmrid(dmr_id: int, expected_status: int, expected_len: int):
 
 
 def test_repeater_location():
-	response = requests.get(url=f"{BASE_URL}/repeater/location?city=Gothenburg&country=SE&distance=40")
+	url = f"http://{hostname}/{API_ROOT}/repeater/location?city=Gothenburg&country=SE&distance=40"
+	response = requests.get(url)
 	assert response.status_code == 501
 
 
@@ -121,23 +133,25 @@ def test_repeater_location():
 		"valid callsign"
 	]
 )
-def test_hotspot(callsign: str, expected_status: int):
+def test_hotspot(callsign: str, expected_status: int, hostname):
 	"""
 	Given a valid callsign, we expected that will receive a number of hotspots
 	"""
-	response = requests.get(url=f"{BASE_URL}/hotspot/callsign/{callsign}")
+	url = f"http://{hostname}/{API_ROOT}/hotspot/callsign/{callsign}"
+	response = requests.get(url)
 	assert response.status_code == expected_status
 
 
-def test_redirect_root():
+def test_redirect_root(hostname):
 	"""Given a GET request sent towards root, we expect to be redirected to /docs"""
 
 	# call the UUT
-	response = requests.get(url=BASE_URL, allow_redirects=True)
+	url = f"http://{hostname}/{API_ROOT}"
+	response = requests.get(url=url, allow_redirects=True)
 
 	# assert results
 	assert response.status_code == 200
-	assert response.url == f"{BASE_URL}/docs"
+	assert response.url == f"{url}/docs"
 	assert response.history[0].is_redirect
 	assert response.history[0].status_code == 301
 
@@ -155,13 +169,13 @@ def test_redirect_root():
 		"falkenberg+99,distance-invalid"
 	]
 )
-def test_repeater_location(longitude, latitude, distance, limit, expected_status):
+def test_repeater_location(longitude, latitude, distance, limit, expected_status, hostname):
 	"""
 	Given a location in Falkenberg, there is no DMR enabled
 	repeater in that area
 	"""
-
-	req_url = f"{BASE_URL}/repeater/location" + \
+	url = f"http://{hostname}/{API_ROOT}"
+	req_url = f"{url}/repeater/location" + \
 				 f"?longitude={longitude}&latitude={latitude}&distance={distance}"
 
 	if limit:
@@ -187,12 +201,12 @@ def test_repeater_location(longitude, latitude, distance, limit, expected_status
 		"invalid => 422"
 	]
 )
-def test_user_dmrid(dmr_id, expected_status):
+def test_user_dmrid(dmr_id, expected_status, hostname):
 	"""
 	Given a valid user DMR ID, I expect the UUT to return a User response
 	"""
 	sleep(2)
-	req_url = f"{BASE_URL}/user/{dmr_id}"
+	req_url = f"http://{hostname}/{API_ROOT}/user/{dmr_id}"
 
 	response = requests.get(url=req_url)
 
@@ -202,14 +216,14 @@ def test_user_dmrid(dmr_id, expected_status):
 		data = response.json()
 		assert data['call_sign'] == "SM0TSC"
 
-def test_request_limiter():
+def test_request_limiter(hostname):
 	"""
 	Given that we have configured the NGINX proxy with request limiting
 	we should never receive 503, instead requests are delayed before served
 	"""
 	sleep(4)
 	counter = 20
-	url = f"{BASE_URL}/system/info"
+	url = f"http://{hostname}/{API_ROOT}/system/info"
 	while counter > 0:
 		counter -= 1
 		response = requests.get(url=url)


### PR DESCRIPTION
- add new member "user" to JSON structure returned for
  GET => /system/info
- provide function tests for new member in system/info
  return JSON data
- ensure that we set both "repeater" and "user" to 0
  if we won't be able to find any collection (initialized
  database will take some time to populate the data)
- prepare the function tests for being reused when
  deploying to production, introduces a host name that
  can be passed when running the function test against a 
  certain host