### PR TITLE
Fix ESP32 CI setup

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,14 +8,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: install dependencies
       run: curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sudo BINDIR=/usr/local/bin sh
     - name: Arduino, CLI update
       run: make update
     - name: Arduino, make ESP32 binary
-      run: make binary
+      run: make esp-binary

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SOURCES_H = $(wildcard ${SOURCEDIR}/*.h)
 ARDUINO_BOARD_FQDN = "esp32:esp32:esp32-DevKitLipo"
 ARDUINO_PROGRAMMER_PORT = /dev/ttyUSB0
 ARDUINO_CLI_DOCKER_TAG = local/arduino-cli:latest
+ARDUINO_CLI_CONFIG = --config-file arduino-cli.yaml
 BUILD_DIR = build
 RELEASE_VERSION_STRING=$(shell sed -n 's/^.*SoftwareVersion.* *= *//p' sketch_dreambox/sketch_dreambox.ino | sed 's/[;"]*//g')
 RELEASE_NAME = ${RELEASE_VERSION_STRING}
@@ -42,7 +43,7 @@ ${BUILD_DIR}/%.bin: venv Makefile ${SOURCES_C} ${SOURCES_H}
 	@test -d ${BUILD_DIR} || mkdir -p ${BUILD_DIR}
 	@( \
 		. .venv/bin/activate ; \
-		arduino-cli compile --config-file arduino-cli.yaml --output-dir ${BUILD_DIR} --fqbn ${ARDUINO_BOARD_FQDN} ${SOURCEDIR}/ ; \
+		arduino-cli compile ${ARDUINO_CLI_CONFIG} --output-dir ${BUILD_DIR} --fqbn ${ARDUINO_BOARD_FQDN} ${SOURCEDIR}/ ; \
 	)
 
 esp-upload: esp-binary
@@ -112,7 +113,7 @@ clean-all: clean
 	rm -rf Arduino/
 
 update:
-	arduino-cli update --config-file arduino-cli.yaml
+	arduino-cli update ${ARDUINO_CLI_CONFIG}
 
 
 libs: .built-libs
@@ -130,11 +131,11 @@ venv: .built-venv
 
 .built-libs: requirements.libraries.txt
 	@echo "==> Installing libraries ***"
-	arduino-cli lib update-index
+	arduino-cli lib update-index ${ARDUINO_CLI_CONFIG}
 	@if [ -e $< ]; \
 	then while read -r i ; do echo ; \
 	  echo "---> Installing " '"'$$i'"' ; \
-	  arduino-cli lib install "$$i" ; \
+	  arduino-cli lib install ${ARDUINO_CLI_CONFIG} "$i" ; \
 	  touch $@; \
 	done < $< ; \
 	else echo "---> MISSING boards.arduino.txt file"; \
@@ -144,11 +145,11 @@ boards: .built-boards
 
 .built-boards: requirements.boards.txt
 	@echo "==> Installing board support ***"
-	arduino-cli core update-index
+	arduino-cli core update-index ${ARDUINO_CLI_CONFIG}
 	@if [ -e $< ]; \
 	then while read -r i ; do echo ; \
 	  echo "---> Installing " '"'$$i'"' ; \
-	  arduino-cli core install "$$i" ; \
+	  arduino-cli core install ${ARDUINO_CLI_CONFIG} "$i" ; \
 	  touch $@ ; \
 	done < $< ; \
 	else echo "---> MISSING requirements.boards.txt file"; \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ${BUILD_DIR}/%.bin: venv Makefile ${SOURCES_C} ${SOURCES_H}
 	@test -d ${BUILD_DIR} || mkdir -p ${BUILD_DIR}
 	@( \
 		. .venv/bin/activate ; \
-		arduino-cli compile ${ARDUINO_CLI_CONFIG} --output-dir ${BUILD_DIR} --fqbn ${ARDUINO_BOARD_FQDN} ${SOURCEDIR}/ ; \
+		arduino-cli ${ARDUINO_CLI_CONFIG} compile --output-dir ${BUILD_DIR} --fqbn ${ARDUINO_BOARD_FQDN} ${SOURCEDIR}/ ; \
 	)
 
 esp-upload: esp-binary
@@ -113,7 +113,7 @@ clean-all: clean
 	rm -rf Arduino/
 
 update:
-	arduino-cli update ${ARDUINO_CLI_CONFIG}
+	arduino-cli ${ARDUINO_CLI_CONFIG} update
 
 
 libs: .built-libs
@@ -131,11 +131,11 @@ venv: .built-venv
 
 .built-libs: requirements.libraries.txt
 	@echo "==> Installing libraries ***"
-	arduino-cli lib update-index ${ARDUINO_CLI_CONFIG}
+	arduino-cli ${ARDUINO_CLI_CONFIG} lib update-index
 	@if [ -e $< ]; \
 	then while read -r i ; do echo ; \
 	  echo "---> Installing " '"'$$i'"' ; \
-	  arduino-cli lib install ${ARDUINO_CLI_CONFIG} "$i" ; \
+	  arduino-cli ${ARDUINO_CLI_CONFIG} lib install "$$i" ; \
 	  touch $@; \
 	done < $< ; \
 	else echo "---> MISSING boards.arduino.txt file"; \
@@ -145,11 +145,11 @@ boards: .built-boards
 
 .built-boards: requirements.boards.txt
 	@echo "==> Installing board support ***"
-	arduino-cli core update-index ${ARDUINO_CLI_CONFIG}
+	arduino-cli ${ARDUINO_CLI_CONFIG} core update-index
 	@if [ -e $< ]; \
 	then while read -r i ; do echo ; \
 	  echo "---> Installing " '"'$$i'"' ; \
-	  arduino-cli core install ${ARDUINO_CLI_CONFIG} "$i" ; \
+	  arduino-cli ${ARDUINO_CLI_CONFIG} core install "$$i" ; \
 	  touch $@ ; \
 	done < $< ; \
 	else echo "---> MISSING requirements.boards.txt file"; \

--- a/arduino-cli.yaml
+++ b/arduino-cli.yaml
@@ -1,11 +1,11 @@
 board_manager:
-  additional_urls: 
+  additional_urls:
     - 'https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json'
 daemon:
   port: "50051"
 directories:
   data: ./Arduino/data
-  downloads: /home/bastian/.arduino15/staging
+  downloads: ./Arduino/staging
   user: ./Arduino/user
 library:
   enable_unsafe_install: false


### PR DESCRIPTION
## What changed

- use a repository-relative Arduino CLI downloads directory
- update `actions/checkout` from v2 to v4
- invoke the existing `make esp-binary` target

## Why

The ESP32 workflow failed before compilation because `arduino-cli.yaml` tried to create `/home/bastian/.arduino15/staging` on the GitHub-hosted runner. The next build command also referenced a non-existent `make binary` target.

## Validation

- confirmed the Makefile exposes `esp-binary`
- confirmed `make -n update` resolves successfully
- CI will validate Arduino CLI setup and the complete firmware build